### PR TITLE
Catch ExecException and add unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This repository contains a Gradle plugin to help with interacting with Maven rep
 It is basically a copy of [Artifact Registry Maven Tools](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools) but only for Gradle
 and more up to date.
 
+## Usage
+```kts
+id("io.github.bjoernmayer.artifactregistryGradlePlugin") version "0.1.1"
+```
+
 ## Authentication
 
 Requests to Artifact Registry will be authenticated using credentials from the environment. The

--- a/artifactregistry-gradle-plugin/build.gradle.kts
+++ b/artifactregistry-gradle-plugin/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation(gradleApi())
     implementation("com.google.auth:google-auth-library-oauth2-http:1.23.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.2")
+    testImplementation("io.mockk:mockk:1.13.10")
 }
 
 group = "io.github.bjoernmayer"
@@ -39,4 +42,8 @@ gradlePlugin {
         description = "Automatically handle authentication with Maven repositories hosted on Artifact Registry."
         tags = listOf("maven", "artifact", "repositories", "googleCloud")
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/ArtifactRegistryPasswordCredentialsSupplier.kt
+++ b/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/ArtifactRegistryPasswordCredentialsSupplier.kt
@@ -1,8 +1,8 @@
 package io.github.bjoernmayer.artifactregistrygradle
 
+import com.google.auth.oauth2.GoogleCredentials
 import io.github.bjoernmayer.artifactregistrygradle.googleCredentialsSupplier.ApplicationDefault
 import io.github.bjoernmayer.artifactregistrygradle.googleCredentialsSupplier.GCloudSDK
-import com.google.auth.oauth2.GoogleCredentials
 import org.gradle.api.provider.ProviderFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDK.kt
+++ b/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDK.kt
@@ -7,6 +7,7 @@ import com.google.api.client.util.GenericData
 import com.google.auth.oauth2.AccessToken
 import com.google.auth.oauth2.GoogleCredentials
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.process.internal.ExecException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.IOException
@@ -31,6 +32,9 @@ internal class GCloudSDK(
                 logger.info("Using credentials retrieved from gcloud.")
             }
         } catch (e: IOException) {
+            logger.info("Failed to retrieve credentials from gcloud: " + e.message)
+            null
+        } catch (e: ExecException) {
             logger.info("Failed to retrieve credentials from gcloud: " + e.message)
             null
         }

--- a/artifactregistry-gradle-plugin/src/test/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDKTest.kt
+++ b/artifactregistry-gradle-plugin/src/test/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDKTest.kt
@@ -1,0 +1,22 @@
+package io.github.bjoernmayer.artifactregistrygradle.googleCredentialsSupplier
+
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.process.internal.ExecException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GCloudSDKTest {
+    @Test
+    fun `test gcloud command throws exec exception, get should return null`() {
+        val providerFactory: ProviderFactory =
+            mockk {
+                every {
+                    exec(any())
+                } throws ExecException("A problem occurred starting process 'command 'gcloud'")
+            }
+
+        assertEquals(null, GCloudSDK(providerFactory).get())
+    }
+}


### PR DESCRIPTION
When `gcloud` was not found on the machine, Gradle throws an `ExecException`. This was not caught and therefore the plugin could not be applied

With this PR `ExecException` is caught