### PR TITLE
Catch and rethrow execException as IOException

### DIFF
--- a/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDK.kt
+++ b/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDK.kt
@@ -34,9 +34,6 @@ internal class GCloudSDK(
         } catch (e: IOException) {
             logger.info("Failed to retrieve credentials from gcloud: " + e.message)
             null
-        } catch (e: ExecException) {
-            logger.info("Failed to retrieve credentials from gcloud: " + e.message)
-            null
         }
     }
 
@@ -72,7 +69,7 @@ internal class GCloudSDK(
         }
 
         override fun get(): AccessToken {
-            val execOutput =
+            val execOutput = try {
                 providerFactory.exec {
                     it.commandLine(
                         gCloudCommand,
@@ -81,6 +78,9 @@ internal class GCloudSDK(
                         "--format=json(credential)",
                     )
                 }
+            } catch (e: ExecException) {
+                throw IOException(e)
+            }
 
             val exitCode = execOutput.result.get().exitValue
             val stdOut = execOutput.standardOutput.asText.get()

--- a/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDK.kt
+++ b/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/GCloudSDK.kt
@@ -69,18 +69,19 @@ internal class GCloudSDK(
         }
 
         override fun get(): AccessToken {
-            val execOutput = try {
-                providerFactory.exec {
-                    it.commandLine(
-                        gCloudCommand,
-                        "config",
-                        "config-helper",
-                        "--format=json(credential)",
-                    )
+            val execOutput =
+                try {
+                    providerFactory.exec {
+                        it.commandLine(
+                            gCloudCommand,
+                            "config",
+                            "config-helper",
+                            "--format=json(credential)",
+                        )
+                    }
+                } catch (e: ExecException) {
+                    throw IOException(e)
                 }
-            } catch (e: ExecException) {
-                throw IOException(e)
-            }
 
             val exitCode = execOutput.result.get().exitValue
             val stdOut = execOutput.standardOutput.asText.get()


### PR DESCRIPTION
It could still happen, that a ExecException bubbled up into places, where it cannot be handled.

With this PR, all ExecExceptions in `GCloudSDK` are caught and rethrown as IOException