### PR TITLE
Downgrade guava to the same version as used in original plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Artifact Registry Gradle
 
+[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v?label=Plugin%20Portal&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fio%2Fgithub%2Fbjoernmayer%2FartifactregistryGradlePlugin%2Fio.github.bjoernmayer.artifactregistryGradlePlugin.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/io.github.bjoernmayer.artifactregistryGradlePlugin)
+
 This repository contains a Gradle plugin to help with interacting with Maven repositories hosted on Artifact Registry.
 
 It is basically a copy of [Artifact Registry Maven Tools](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools) but only for Gradle and more up to date.
@@ -11,7 +13,7 @@ Apply the plugin:
 - In `settings.gradle.kts` for multi module projects
 
 ```kts
-id("io.github.bjoernmayer.artifactregistryGradlePlugin") version "0.2.1"
+id("io.github.bjoernmayer.artifactregistryGradlePlugin") version "<VERSION>"
 ```
 
 ## Authentication

--- a/artifactregistry-gradle-plugin/build.gradle.kts
+++ b/artifactregistry-gradle-plugin/build.gradle.kts
@@ -40,7 +40,7 @@ configurations.all {
 }
 
 group = "io.github.bjoernmayer"
-version = "0.2.1"
+version = "0.2.2"
 
 gradlePlugin {
     website = "https://github.com/bjoernmayer/artifactregistry-gradle"

--- a/artifactregistry-gradle-plugin/build.gradle.kts
+++ b/artifactregistry-gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
     // https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http
-    implementation("com.google.auth:google-auth-library-oauth2-http:1.23.0")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.1.0") // 30.1.1
 
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")

--- a/artifactregistry-gradle-plugin/build.gradle.kts
+++ b/artifactregistry-gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
     // https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http
-    implementation("com.google.auth:google-auth-library-oauth2-http:1.1.0") // 30.1.1
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.1.0")
 
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")


### PR DESCRIPTION
This downgrades `com.google.auth:google-auth-library-oauth2-http` to `1.1.0` in order to use the same guava version as the original plugin