### PR TITLE
Use newer version of google-auth-library-oauth2-http, Jib Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Apply the plugin:
 id("io.github.bjoernmayer.artifactregistryGradlePlugin") version "<VERSION>"
 ```
 
+### Using with Jib in a multi module project
+If you see weird errors like `NoSuchMethod`, you might need to pin down the guava version for your buildscript:
+```kts
+// root settings.gradle.kts
+buildscript {
+    dependencies {
+        classpath("com.google.guava:guava:33.2.0-jre")
+    }
+}
+```
+
 ## Authentication
 
 Requests to Artifact Registry will be authenticated using credentials from the environment. The

--- a/artifactregistry-gradle-plugin/build.gradle.kts
+++ b/artifactregistry-gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
     // https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http
-    implementation("com.google.auth:google-auth-library-oauth2-http:1.1.0")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.23.0")
 
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")

--- a/artifactregistry-gradle-plugin/build.gradle.kts
+++ b/artifactregistry-gradle-plugin/build.gradle.kts
@@ -40,7 +40,7 @@ configurations.all {
 }
 
 group = "io.github.bjoernmayer"
-version = "0.2.2"
+version = "0.2.3"
 
 gradlePlugin {
     website = "https://github.com/bjoernmayer/artifactregistry-gradle"


### PR DESCRIPTION
As the guava version can be easily set for a buildScript, the change from 0.2.2 can be reverted