### PR TITLE
Use provider to fetch google application credentials

### DIFF
--- a/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/ArtifactRegistryGradlePlugin.kt
+++ b/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/ArtifactRegistryGradlePlugin.kt
@@ -16,7 +16,7 @@ class ArtifactRegistryGradlePlugin : Plugin<Any> {
     private val artifactRegistryPasswordCredentialsSupplier: ArtifactRegistryPasswordCredentialsSupplier by lazy {
         ArtifactRegistryPasswordCredentialsSupplier(
             listOf(
-                ApplicationDefault,
+                ApplicationDefault(providerFactory),
                 GCloudSDK(providerFactory),
             ),
         )


### PR DESCRIPTION
In CI the value of the `GOOGLE_APPLICATION_CREDENTIALS` env var changes with every run. Then gradle cannot reuse the configuration cache:

> Calculating task graph as configuration cache cannot be reused because environment variable 'GOOGLE_APPLICATION_CREDENTIALS' has changed.

This PR addresses this by using a provider to get the value of the env var.