### PR TITLE
Replace System.getProperty with provider

### DIFF
--- a/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/ApplicationDefault.kt
+++ b/artifactregistry-gradle-plugin/src/main/kotlin/io/github/bjoernmayer/artifactregistrygradle/googleCredentialsSupplier/ApplicationDefault.kt
@@ -23,8 +23,12 @@ class ApplicationDefault(private val providerFactory: ProviderFactory) : Supplie
 
         return try {
             val credentialsPath =
-                providerFactory.environmentVariable(APPLICATION_CREDENTIALS_ENV_VAR_NAME).orNull?.takeIf { it.isNotBlank() }
+                providerFactory
+                    .environmentVariable(APPLICATION_CREDENTIALS_ENV_VAR_NAME)
+                    .orNull
+                    ?.takeIf { it.isNotBlank() }
                     ?: throw IOException("GOOGLE_APPLICATION_CREDENTIALS Env Var not set or empty")
+
             val credentialsInputStream = FileInputStream(File(credentialsPath))
 
             GoogleCredentials


### PR DESCRIPTION
One more change to make this plugin more compatible with config cache.

Also:
Make sure to catch every exception that `exec` might throw and debug log it.